### PR TITLE
build(dependencies): bump imagemin-optipng to ^4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "html-webpack-plugin": "^3.2.0",
     "image-webpack-loader": "^4.3.1",
     "imagemin": "^6.0.0",
-    "imagemin-optipng": "^5.2.1",
+    "imagemin-optipng": "^6.0.0",
     "imagemin-pngquant": "^6.0.0",
     "mini-css-extract-plugin": "^0.4.2",
     "node-sass": "^4.11.0",


### PR DESCRIPTION
This removes a warning shown by npm caused by older versions of `imagemin-optipng` including a
deprecated version of `gulp-util` in its dependency tree.

Based on [comments][comments] by the package maintainer, this shouldn't cause any breaking changes despite the major version change.

[comments]: https://github.com/imagemin/imagemin-optipng/commit/9140df1b0ce805b9f096f22ab3d4132f8fa77aa9#commitcomment-24601188